### PR TITLE
Add image rebuild workflow

### DIFF
--- a/.github/workflows/check_rebuild_tempest.yaml
+++ b/.github/workflows/check_rebuild_tempest.yaml
@@ -22,34 +22,49 @@ jobs:
           sudo snap install yq
       - name: Check if a recent snap updates is found
         id: check
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # get the snap name and its channel that the ROCK image should track
           snap=$(yq '.parts.[].stage-snaps.[]' rocks/tempest/rockcraft.yaml)
           IFS='/' read -r name channel <<< "$snap"
           echo "snap: $name, channel: $channel"
 
+          image_version=$(yq '.version' rocks/tempest/rockcraft.yaml)
+          echo "image version: $image_version"
+
           # parse date of the last release and reformat it to seconds
           format='+%s'
-          last_release_date=$(snap info tempest | grep "2023.2/stable" | awk '{ print $3 }')
-          echo "last release date in channel $channel: $last_release_date"
-          last_release_date_in_seconds=$(date -d "$last_release_date" "$format")
+          snap_update_date=$(snap info $name | grep $channel | awk '{ print $3 }')
+          echo "last update date for snap $name in $channel: $snap_update_date"
+          snap_update_date_in_seconds=$(date -d "$snap_update_date" "$format")
 
-          # confirm the validity of the release date
-          if [[ $? != 0 ]]; then
-            echo "$last_release_date is not a valid date."
+          # confirm the validity of the snap release date
+          if [[ "$?" != 0 ]]; then
+            echo "$snap_update_date is not a valid date."
+            exit 1
           fi
 
-          # get current date and reformat it to seconds
-          cur_date=$(date)
-          echo "current date: $cur_date"
-          cur_date_in_seconds=$(date -d "$cur_date" "$format")
+          # get the last image update date and reformat it to seconds
+          image_update_date=$(curl -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $TOKEN" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/orgs/canonical/packages/container/tempest/versions | yq '.[] | select(.metadata.container.tags[0]==$image_version) | .updated_at')
+          echo "last update date for image tempest tag $image_version: $image_update_date"
 
-          # get the date difference between two days
-          date_diff=$(( ($cur_date_in_seconds - $last_release_date_in_seconds)/(60*60*24) ))
+          # exit unsuccessfully if the image tag is not found in registry (to be safe we only update image with exiting tags)
+          if [[ -z "$image_update_date" ]]; then
+            echo "Tempest image with tag '$image_version' not found in registry."
+            exit 1
+          fi
+          image_update_date_in_seconds=$(date -d "$image_update_date" "$format")
+
+          # confirm the validity of the image release date
+          if [[ "$?" != 0 ]]; then
+            echo "$image_update_date is not a valid date."
+            exit 1
+          fi
           
-          # re-build image if the date difference is less than or equal to 5 days
-          if [ $date_diff -le 5 ]; then
-              echo "A recent snap release is found. Will re-build a new image."
+          # re-build and publish image if the image update date is earlier than snap update date
+          if [ "$image_update_date_in_seconds" -lt "$snap_update_date_in_seconds" ]; then
+              echo "A recent snap release is found. Will re-build and publish a new image."
               echo "rebuild_image=1" >> $GITHUB_OUTPUT
           else
               echo "No new snap releases detected."

--- a/.github/workflows/check_rebuild_tempest.yaml
+++ b/.github/workflows/check_rebuild_tempest.yaml
@@ -1,0 +1,66 @@
+name: Check and Rebuild Tempest Image
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        description: The branch to run checks on and re-build images from
+        type: string
+        required: true
+
+jobs:
+  check-update:
+    runs-on: ubuntu-latest
+    outputs:
+      rebuild_image: ${{ steps.check.outputs.rebuild_image }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+      - name: Install yq
+        run: |
+          sudo snap install yq
+      - name: Check if a recent snap updates is found
+        id: check
+        run: |
+          # get the snap name and its channel that the ROCK image should track
+          snap=$(yq '.parts.[].stage-snaps.[]' rocks/tempest/rockcraft.yaml)
+          IFS='/' read -r name channel <<< "$snap"
+          echo "snap: $name, channel: $channel"
+
+          # parse date of the last release and reformat it to seconds
+          format='+%s'
+          last_release_date=$(snap info tempest | grep "2023.2/stable" | awk '{ print $3 }')
+          echo "last release date in channel $channel: $last_release_date"
+          last_release_date_in_seconds=$(date -d "$last_release_date" "$format")
+
+          # confirm the validity of the release date
+          if [[ $? != 0 ]]; then
+            echo "$last_release_date is not a valid date."
+          fi
+
+          # get current date and reformat it to seconds
+          cur_date=$(date)
+          echo "current date: $cur_date"
+          cur_date_in_seconds=$(date -d "$cur_date" "$format")
+
+          # get the date difference between two days
+          date_diff=$(( ($cur_date_in_seconds - $last_release_date_in_seconds)/(60*60*24) ))
+          
+          # re-build image if the date difference is less than or equal to 5 days
+          if [ $date_diff -le 5 ]; then
+              echo "A recent snap release is found. Will re-build a new image."
+              echo "rebuild_image=1" >> $GITHUB_OUTPUT
+          else
+              echo "No new snap releases detected."
+              echo "rebuild_image=0" >> $GITHUB_OUTPUT
+          fi
+
+  build-and-publish:
+    needs: check-update
+    if: ${{ needs.check-update.outputs.rebuild_image == 1 }}
+    uses: ./.github/workflows/build_publish.yaml
+    with:
+      rocks: '["tempest"]'
+      branch: ${{ inputs.branch }}
+      publish: true

--- a/.github/workflows/update_tempest_releases.yaml
+++ b/.github/workflows/update_tempest_releases.yaml
@@ -1,0 +1,15 @@
+name: Update Tempest Releases
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '12 1 * * 1,4' # run workflow at 1:12 (an arbitrary time) every Mon and Thu 
+
+jobs:
+  check-update:
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ["main", "stable/2023.1"]
+    uses: ./.github/workflows/check_rebuild_tempest.yaml
+    with:
+      branch: ${{ matrix.branch }}

--- a/.github/workflows/update_tempest_releases.yaml
+++ b/.github/workflows/update_tempest_releases.yaml
@@ -5,11 +5,42 @@ on:
     - cron: '12 1 * * 1,4'  # run workflow at 1:12 (an arbitrary time) every Mon and Thu 
 
 jobs:
+  get_release_branches:
+    runs-on: ubuntu-latest
+    outputs:
+      branches: ${{ steps.get-branches.outputs.branches }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install jq
+        run: |
+          sudo apt install jq
+      - name: Get branches
+        id: get-branches
+        run: |
+          # filter branches prefixed with `stable/*` in remote repo
+          filtered_branches=$(git branch -a --list "origin/stable/*" --format='%(refname:short)' | sed 's/origin\///')
+
+          # add `main` branch as it tracks the latest release in development
+          branches_array="main"
+
+          # create a json list of branches
+          while IFS= read -r line
+          do
+            branches_array+=($line)
+          done < <(printf '%s\n' "$filtered_branches")
+          branches_json=$(jq -c -n '$ARGS.positional' --args -- "${branches_array[@]}")
+          echo $branches_json
+
+          echo "branches=$branches_json" >> $GITHUB_OUTPUT
+
   check-update:
+    needs: get_release_branches
     strategy:
       fail-fast: false
       matrix:
-        branch: ["main", "stable/2023.1"]  # for all active OpenStack release branches
+        branch: ${{ fromJson(needs.get_release_branches.outputs.branches) }}
     uses: ./.github/workflows/check_rebuild_tempest.yaml
     with:
       branch: ${{ matrix.branch }}

--- a/.github/workflows/update_tempest_releases.yaml
+++ b/.github/workflows/update_tempest_releases.yaml
@@ -2,14 +2,14 @@ name: Update Tempest Releases
 on:
   workflow_dispatch:
   schedule:
-    - cron: '12 1 * * 1,4' # run workflow at 1:12 (an arbitrary time) every Mon and Thu 
+    - cron: '12 1 * * 1,4'  # run workflow at 1:12 (an arbitrary time) every Mon and Thu 
 
 jobs:
   check-update:
     strategy:
       fail-fast: false
       matrix:
-        branch: ["main", "stable/2023.1"]
+        branch: ["main", "stable/2023.1"]  # for all active OpenStack release branches
     uses: ./.github/workflows/check_rebuild_tempest.yaml
     with:
       branch: ${{ matrix.branch }}

--- a/rocks/tempest/rockcraft.yaml
+++ b/rocks/tempest/rockcraft.yaml
@@ -15,13 +15,13 @@ platforms:
   amd64:
 
 parts:
-    snap-tempest:
-      plugin: python
-      source: .
-      stage-snaps:
-      - tempest/2023.2/stable
-      stage-packages:
-      - cron
-      - python3-venv
-      python-packages:
-      - croniter
+  snap-tempest:
+    plugin: python
+    source: .
+    stage-snaps:
+    - tempest/2023.2/stable
+    stage-packages:
+    - cron
+    - python3-venv
+    python-packages:
+    - croniter


### PR DESCRIPTION
Workflow to run periodic snap release check for all os-release branches. If a recent snap release is detected, it will build and publish image.